### PR TITLE
feat: replace CIMPL charts with osdu-spi-service local Helm chart

### DIFF
--- a/software/stack/charts/osdu-spi-service/Chart.yaml
+++ b/software/stack/charts/osdu-spi-service/Chart.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026, Microsoft
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: osdu-spi-service
+description: Generic OSDU service chart for Azure SPI deployments with AKS Automatic compliance
+type: application
+version: 0.1.0
+appVersion: "master"

--- a/software/stack/charts/osdu-spi-service/templates/_helpers.tpl
+++ b/software/stack/charts/osdu-spi-service/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/*
+Copyright 2026, Microsoft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+*/}}
+
+{{/* Chart name, truncated to 63 chars */}}
+{{- define "osdu-spi-service.name" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Selector labels */}}
+{{- define "osdu-spi-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "osdu-spi-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Common labels */}}
+{{- define "osdu-spi-service.labels" -}}
+{{ include "osdu-spi-service.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: osdu
+{{- end }}

--- a/software/stack/charts/osdu-spi-service/templates/deployment.yaml
+++ b/software/stack/charts/osdu-spi-service/templates/deployment.yaml
@@ -1,0 +1,153 @@
+{{/*
+Copyright 2026, Microsoft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+*/}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "osdu-spi-service.name" . }}
+  labels:
+    {{- include "osdu-spi-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "osdu-spi-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "osdu-spi-service.selectorLabels" . | nindent 8 }}
+        {{- if .Values.workloadIdentity }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      {{- if .Values.istioProxyPin.enabled }}
+      annotations:
+        sidecar.istio.io/proxyImage: {{ .Values.istioProxyPin.image }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccountName }}
+
+      # -- AKS Automatic / Deployment Safeguards compliance
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+
+      {{- if .Values.topologySpread }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "osdu-spi-service.selectorLabels" . | nindent 14 }}
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "osdu-spi-service.selectorLabels" . | nindent 14 }}
+      {{- end }}
+
+      {{- if .Values.elasticTls }}
+      initContainers:
+        - name: import-elastic-ca
+          image: eclipse-temurin:17-jre-alpine
+          command:
+            - sh
+            - -c
+            - |
+              cp $JAVA_HOME/lib/security/cacerts /truststore/cacerts
+              keytool -importcert -noprompt -keystore /truststore/cacerts \
+                -storepass changeit -alias elastic-ca -file /elastic-ca/ca.crt
+          volumeMounts:
+            - name: elastic-ca
+              mountPath: /elastic-ca
+              readOnly: true
+            - name: truststore
+              mountPath: /truststore
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+      {{- end }}
+
+      containers:
+        - name: {{ include "osdu-spi-service.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: {{ .Values.probes.liveness.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: {{ .Values.probes.readiness.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.configMapRef }}
+          {{- if or .Values.env .Values.elasticTls }}
+          env:
+            {{- if .Values.elasticTls }}
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Djavax.net.ssl.trustStore=/truststore/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+            {{- end }}
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.elasticTls }}
+          volumeMounts:
+            - name: truststore
+              mountPath: /truststore
+              readOnly: true
+          {{- end }}
+
+      {{- if .Values.elasticTls }}
+      volumes:
+        - name: elastic-ca
+          secret:
+            secretName: elastic-ca-cert
+        - name: truststore
+          emptyDir: {}
+      {{- end }}

--- a/software/stack/charts/osdu-spi-service/templates/service.yaml
+++ b/software/stack/charts/osdu-spi-service/templates/service.yaml
@@ -1,0 +1,25 @@
+{{/*
+Copyright 2026, Microsoft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "osdu-spi-service.name" . }}
+  labels:
+    {{- include "osdu-spi-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "osdu-spi-service.selectorLabels" . | nindent 4 }}

--- a/software/stack/charts/osdu-spi-service/values.yaml
+++ b/software/stack/charts/osdu-spi-service/values.yaml
@@ -1,0 +1,80 @@
+# Copyright 2026, Microsoft
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -- Image configuration
+image:
+  repository: ""
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+# -- Container port the service listens on
+containerPort: 8080
+
+# -- Service account (created by osdu-common module)
+serviceAccountName: workload-identity-sa
+
+# -- ConfigMap mounted as envFrom (created by osdu-common module)
+configMapRef: osdu-config
+
+# -- Kubernetes Service
+service:
+  type: ClusterIP
+  port: 80
+
+# -- Health probes
+probes:
+  liveness:
+    path: /actuator/health
+    port: 8081
+    initialDelaySeconds: 250
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    path: /actuator/health
+    port: 8081
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# -- Resource requests and limits
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+# -- Extra environment variables (list of {name, value} objects)
+env: []
+# - name: FOO
+#   value: bar
+
+# -- Workload identity pod label
+workloadIdentity: true
+
+# -- Elasticsearch TLS init container (for search/indexer)
+elasticTls: false
+
+# -- Topology spread constraints
+topologySpread: true
+
+# -- Pin Istio sidecar proxy image
+istioProxyPin:
+  enabled: false
+  image: mcr.microsoft.com/oss/v2/istio/proxyv2:v1.28.3-2

--- a/software/stack/locals.tf
+++ b/software/stack/locals.tf
@@ -72,4 +72,28 @@ locals {
 
   # Middleware deploy flags
   deploy_postgresql_airflow = var.enable_airflow
+
+  # -- OSDU service image resolution ----------------------------------------
+  # Azure SPI images from the OSDU community registry. Image names follow the
+  # pattern: {service}-{branch}:{full_40char_git_sha}
+  # Per-service overrides via var.osdu_image_overrides take full precedence.
+  _osdu_image_defaults = {
+    partition      = { repository = "community.opengroup.org:5555/osdu/platform/system/partition/partition-${var.osdu_image_branch}", tag = "119bf4d9e25879e5f47206dcf24b4998ee4eb355" }
+    entitlements   = { repository = "community.opengroup.org:5555/osdu/platform/security-and-compliance/entitlements/entitlements-${var.osdu_image_branch}", tag = "0fb954f01c7ef59a68194c88dec4d8d166d0b48e" }
+    legal          = { repository = "community.opengroup.org:5555/osdu/platform/security-and-compliance/legal/legal-${var.osdu_image_branch}", tag = "2e82d5975a49564b64574190e492af403164637d" }
+    schema         = { repository = "community.opengroup.org:5555/osdu/platform/system/schema-service/schema-service-${var.osdu_image_branch}", tag = "868023373a2f7550d9f3e850d06434838eeeb2b4" }
+    storage        = { repository = "community.opengroup.org:5555/osdu/platform/system/storage/storage-${var.osdu_image_branch}", tag = "13d0a957c558dd109dd1bb4fb705de583cdc295c" }
+    search         = { repository = "community.opengroup.org:5555/osdu/platform/system/search-service/search-service-${var.osdu_image_branch}", tag = "1756362704ad9ee2b63c83562cebcd9abd233e26" }
+    indexer        = { repository = "community.opengroup.org:5555/osdu/platform/system/indexer-service/indexer-service-${var.osdu_image_branch}", tag = "4a2bd12e73f914460c93aade608287d16e42e2ce" }
+    indexer_queue  = { repository = "community.opengroup.org:5555/osdu/platform/system/indexer-queue/indexer-queue-${var.osdu_image_branch}", tag = "1ad21add706aecd9d1762998113d5976443a4d57" }
+    file           = { repository = "community.opengroup.org:5555/osdu/platform/system/file/file-${var.osdu_image_branch}", tag = "2b149c5ec48451034fbc2562c7cbe622f41843d1" }
+    workflow       = { repository = "community.opengroup.org:5555/osdu/platform/data-flow/ingestion/ingestion-workflow/ingestion-workflow-${var.osdu_image_branch}", tag = "13fbcfce32601edbfc1c10a1994f8af5a388436f" }
+    crs_conversion = { repository = "community.opengroup.org:5555/osdu/platform/system/reference/crs-conversion-service/crs-conversion-service-${var.osdu_image_branch}", tag = "43adf2bef10e3e6d3980b4ff74f78e1aff0c2880" }
+    crs_catalog    = { repository = "community.opengroup.org:5555/osdu/platform/system/reference/crs-catalog-service/crs-catalog-service-${var.osdu_image_branch}", tag = "49761e5b20118a9998b4a2a88d6e57eddd4d745e" }
+    unit           = { repository = "community.opengroup.org:5555/osdu/platform/system/reference/unit-service/unit-service-${var.osdu_image_branch}", tag = "2fdf7e3c4674f87ad0d556e0f1f6da458dac2b18" }
+  }
+
+  osdu_images = {
+    for svc, defaults in local._osdu_image_defaults : svc => lookup(var.osdu_image_overrides, svc, defaults)
+  }
 }

--- a/software/stack/modules/elastic/main.tf
+++ b/software/stack/modules/elastic/main.tf
@@ -22,7 +22,7 @@ resource "kubectl_manifest" "elasticsearch" {
       name: elasticsearch
       namespace: ${var.namespace}
     spec:
-      version: 8.15.2
+      version: 8.18.2
       http:
         service:
           spec:
@@ -122,7 +122,7 @@ resource "kubectl_manifest" "kibana" {
       name: kibana
       namespace: ${var.namespace}
     spec:
-      version: 8.15.2
+      version: 8.18.2
       count: 1
       elasticsearchRef:
         name: elasticsearch

--- a/software/stack/modules/osdu-common/main.tf
+++ b/software/stack/modules/osdu-common/main.tf
@@ -52,19 +52,22 @@ resource "kubernetes_config_map_v1" "osdu_config" {
   }
 
   data = {
-    domain               = var.osdu_domain
-    data_partition       = var.data_partition
-    azure_tenant_id      = var.azure_tenant_id
-    keyvault_uri         = var.keyvault_uri
-    keyvault_name        = var.keyvault_name
-    cosmosdb_endpoint    = var.cosmosdb_endpoint
-    cosmosdb_database    = var.cosmosdb_database
-    storage_account_name = var.storage_account_name
-    servicebus_namespace = var.servicebus_namespace
-    redis_hostname       = var.redis_hostname
-    redis_port           = var.redis_port
-    appinsights_key      = var.appinsights_key
-    elasticsearch_host   = var.elasticsearch_host
+    DOMAIN               = var.osdu_domain
+    DATA_PARTITION       = var.data_partition
+    AZURE_TENANT_ID      = var.azure_tenant_id
+    AAD_CLIENT_ID        = var.workload_identity_client_id
+    KEYVAULT_URI         = var.keyvault_uri
+    KEYVAULT_URL         = var.keyvault_uri
+    KEYVAULT_NAME        = var.keyvault_name
+    COSMOSDB_ENDPOINT    = var.cosmosdb_endpoint
+    COSMOSDB_DATABASE    = var.cosmosdb_database
+    STORAGE_ACCOUNT_NAME = var.storage_account_name
+    SERVICEBUS_NAMESPACE = var.servicebus_namespace
+    REDIS_HOSTNAME       = var.redis_hostname
+    REDIS_PORT           = var.redis_port
+    SERVER_PORT          = "8080"
+    APPINSIGHTS_KEY      = var.appinsights_key
+    ELASTICSEARCH_HOST   = var.elasticsearch_host
   }
 
   lifecycle {

--- a/software/stack/modules/osdu-spi-service/main.tf
+++ b/software/stack/modules/osdu-spi-service/main.tf
@@ -1,0 +1,59 @@
+# Copyright 2026, Microsoft
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reusable OSDU service deployment using the local osdu-spi-service chart.
+#
+# Replaces the previous osdu-service module that consumed CIMPL Helm charts
+# from OCI registries with kustomize postrender. This module uses a local
+# chart with AKS Automatic compliance baked in (seccomp, security context,
+# topology spread), eliminating the postrender step entirely.
+
+resource "helm_release" "service" {
+  count = var.enable && var.enable_common ? 1 : 0
+
+  name             = var.service_name
+  chart            = "${path.module}/../../charts/osdu-spi-service"
+  namespace        = var.namespace
+  create_namespace = false
+  timeout          = var.timeout
+  atomic           = var.atomic
+
+  values = [yamlencode({
+    image = {
+      repository = var.image_repository
+      tag        = var.image_tag
+    }
+    replicaCount       = var.replica_count
+    containerPort      = var.container_port
+    serviceAccountName = "workload-identity-sa"
+    configMapRef       = "osdu-config"
+    workloadIdentity   = true
+    topologySpread     = true
+    elasticTls         = var.elastic_tls
+    istioProxyPin = {
+      enabled = var.istio_proxy_pin
+      image   = "mcr.microsoft.com/oss/v2/istio/proxyv2:v1.28.3-2"
+    }
+    env       = var.env
+    resources = var.resources
+    probes    = var.probes
+  })]
+
+  lifecycle {
+    precondition {
+      condition     = length(var.preconditions) == 0 || alltrue([for p in var.preconditions : p.condition])
+      error_message = length(var.preconditions) == 0 ? "no preconditions" : join("; ", [for p in var.preconditions : p.error_message if !p.condition])
+    }
+  }
+}

--- a/software/stack/modules/osdu-spi-service/outputs.tf
+++ b/software/stack/modules/osdu-spi-service/outputs.tf
@@ -1,0 +1,23 @@
+# Copyright 2026, Microsoft
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "release_name" {
+  description = "Helm release name"
+  value       = var.enable && var.enable_common ? helm_release.service[0].name : null
+}
+
+output "release_status" {
+  description = "Helm release status"
+  value       = var.enable && var.enable_common ? helm_release.service[0].status : null
+}

--- a/software/stack/modules/osdu-spi-service/variables.tf
+++ b/software/stack/modules/osdu-spi-service/variables.tf
@@ -1,0 +1,158 @@
+# Copyright 2026, Microsoft
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Variables for the reusable OSDU SPI service module
+
+variable "service_name" {
+  description = "Helm release name and Kubernetes resource name"
+  type        = string
+}
+
+variable "image_repository" {
+  description = "Container image repository (e.g. community.opengroup.org:5555/.../partition-master)"
+  type        = string
+}
+
+variable "image_tag" {
+  description = "Container image tag"
+  type        = string
+  default     = "latest"
+}
+
+variable "enable" {
+  description = "Service-level feature flag"
+  type        = bool
+}
+
+variable "enable_common" {
+  description = "Combined gate -- OSDU namespace must exist"
+  type        = bool
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for this service"
+  type        = string
+}
+
+variable "replica_count" {
+  description = "Number of pod replicas"
+  type        = number
+  default     = 1
+}
+
+variable "container_port" {
+  description = "Port the service container listens on"
+  type        = number
+  default     = 8080
+}
+
+variable "elastic_tls" {
+  description = "Enable Elasticsearch TLS init container (for search/indexer)"
+  type        = bool
+  default     = false
+}
+
+variable "istio_proxy_pin" {
+  description = "Pin Istio sidecar proxy to a specific version"
+  type        = bool
+  default     = false
+}
+
+variable "env" {
+  description = "Extra environment variables for the service container"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "resources" {
+  description = "CPU/memory requests and limits"
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  default = {
+    requests = { cpu = "200m", memory = "512Mi" }
+    limits   = { cpu = "1", memory = "1Gi" }
+  }
+}
+
+variable "probes" {
+  description = "Health probe configuration"
+  type = object({
+    liveness = object({
+      path                = string
+      port                = number
+      initialDelaySeconds = number
+      periodSeconds       = number
+      timeoutSeconds      = number
+      failureThreshold    = number
+    })
+    readiness = object({
+      path                = string
+      port                = number
+      initialDelaySeconds = number
+      periodSeconds       = number
+      timeoutSeconds      = number
+      failureThreshold    = number
+    })
+  })
+  default = {
+    liveness = {
+      path                = "/actuator/health"
+      port                = 8081
+      initialDelaySeconds = 250
+      periodSeconds       = 10
+      timeoutSeconds      = 5
+      failureThreshold    = 3
+    }
+    readiness = {
+      path                = "/actuator/health"
+      port                = 8081
+      initialDelaySeconds = 10
+      periodSeconds       = 10
+      timeoutSeconds      = 5
+      failureThreshold    = 3
+    }
+  }
+}
+
+variable "preconditions" {
+  description = "List of precondition checks evaluated before creating the Helm release"
+  type = list(object({
+    condition     = bool
+    error_message = string
+  }))
+  default = []
+}
+
+variable "timeout" {
+  description = "Helm release timeout in seconds"
+  type        = number
+  default     = 1200
+}
+
+variable "atomic" {
+  description = "Purge the release on failure"
+  type        = bool
+  default     = false
+}

--- a/software/stack/osdu-services-core.tf
+++ b/software/stack/osdu-services-core.tf
@@ -14,53 +14,71 @@
 
 # OSDU core service deployments (Azure SPI variant)
 #
-# Key differences from cimpl:
-#   - No cimpl_tenant / cimpl_project / subscriber_private_key_id
-#   - Uses data_partition + workload_identity_client_id
-#   - extra_set references Azure PaaS (Service Bus topics, Redis DB numbers, Storage)
-#   - Preconditions reference Azure PaaS availability, not in-cluster middleware
+# Uses the local osdu-spi-service Helm chart with AKS Automatic compliance
+# baked in (seccomp, security context, topology spread). No kustomize postrender.
+# Images default to OSDU community registry, master branch.
+#
+# Env vars aligned with osdu-developer reference deployment.
 
 module "partition" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "partition"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/system/partition/cimpl-helm"
-  chart                       = "core-plus-partition-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "partition", var.osdu_chart_version)
-  enable                      = local.deploy_partition
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "partition"
+  image_repository = local.osdu_images["partition"].repository
+  image_tag        = local.osdu_images["partition"].tag
+  enable           = local.deploy_partition
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
 
-  extra_set = [
-    {
-      name  = "data.storageAccountName"
-      value = var.storage_account_name
-    },
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "partition" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/partition/v1/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "REDIS_DATABASE", value = "1" },
+    { name = "PARTITION_SPRING_LOGGING_LEVEL", value = "DEBUG" },
   ]
 
   depends_on = [module.osdu_common]
 }
 
 module "entitlements" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "entitlements"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/security-and-compliance/entitlements/cimpl-helm"
-  chart                       = "core-plus-entitlements-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "entitlements", var.osdu_chart_version)
-  enable                      = local.deploy_entitlements
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "entitlements"
+  image_repository = local.osdu_images["entitlements"].repository
+  image_tag        = local.osdu_images["entitlements"].tag
+  enable           = local.deploy_entitlements
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
+
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "entitlements" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/entitlements/v2/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "SPRING_CONFIG_NAME", value = "common,application" },
+    { name = "SERVICE_DOMAIN_NAME", value = "dataservices.energy" },
+    { name = "ROOT_DATA_GROUP_QUOTA", value = "5000" },
+    { name = "REDIS_TTL_SECONDS", value = "1" },
+    { name = "REDIS_DATABASE", value = "2" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+  ]
+
+  probes = {
+    liveness = {
+      path = "/actuator/health", port = 8081
+      initialDelaySeconds = 150, periodSeconds = 10, timeoutSeconds = 5, failureThreshold = 3
+    }
+    readiness = {
+      path = "/actuator/health", port = 8081
+      initialDelaySeconds = 10, periodSeconds = 10, timeoutSeconds = 5, failureThreshold = 3
+    }
+  }
 
   preconditions = [
     { condition = !local.deploy_entitlements || local.deploy_partition, error_message = "Entitlements requires Partition." },
@@ -70,26 +88,32 @@ module "entitlements" {
 }
 
 module "legal" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "legal"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/security-and-compliance/legal/cimpl-helm"
-  chart                       = "core-plus-legal-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "legal", var.osdu_chart_version)
-  enable                      = local.deploy_legal
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "legal"
+  image_repository = local.osdu_images["legal"].repository
+  image_tag        = local.osdu_images["legal"].tag
+  enable           = local.deploy_legal
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
 
-  extra_set = [
-    {
-      name  = "data.servicebusTopic"
-      value = "legaltags"
-    },
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "legal" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/legal/v1/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "SPRING_CONFIG_NAME", value = "common,application" },
+    { name = "COSMOSDB_DATABASE", value = "osdu-db" },
+    { name = "AZURE_STORAGE_ENABLE_HTTPS", value = "true" },
+    { name = "AZURE_STORAGE_CONTAINER_NAME", value = "legal-service-azure-configuration" },
+    { name = "LEGAL_SERVICE_REGION", value = "us" },
+    { name = "SERVICEBUS_TOPIC_NAME", value = "legaltags" },
+    { name = "REDIS_DATABASE", value = "2" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+    { name = "ENTITLEMENTS_SERVICE_ENDPOINT", value = "http://entitlements/api/entitlements/v2" },
+    { name = "ENTITLEMENTS_SERVICE_API_KEY", value = "OBSOLETE" },
   ]
 
   preconditions = [
@@ -101,20 +125,33 @@ module "legal" {
 }
 
 module "schema" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "schema"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/system/schema-service/cimpl-helm"
-  chart                       = "core-plus-schema-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "schema", var.osdu_chart_version)
-  enable                      = local.deploy_schema
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "schema"
+  image_repository = local.osdu_images["schema"].repository
+  image_tag        = local.osdu_images["schema"].tag
+  enable           = local.deploy_schema
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
+
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "schema" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/schema-service/v1/" },
+    { name = "SERVER_PORT", value = "8080" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "COSMOSDB_DATABASE", value = "osdu-db" },
+    { name = "AZURE_SYSTEM_STORAGECONTAINERNAME", value = "system" },
+    { name = "SERVICEBUS_TOPIC_NAME", value = "schemachangedtopic" },
+    { name = "EVENT_GRID_ENABLED", value = "false" },
+    { name = "EVENT_GRID_TOPIC", value = "schemachangedtopic" },
+    { name = "SERVICE_BUS_ENABLED", value = "true" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+    { name = "ENTITLEMENTS_SERVICE_ENDPOINT", value = "http://entitlements/api/entitlements/v2" },
+    { name = "ENTITLEMENTS_SERVICE_API_KEY", value = "OBSOLETE" },
+  ]
 
   preconditions = [
     { condition = !local.deploy_schema || local.deploy_entitlements, error_message = "Schema requires Entitlements." },
@@ -125,30 +162,39 @@ module "schema" {
 }
 
 module "storage" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "storage"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/system/storage/cimpl-helm"
-  chart                       = "core-plus-storage-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "storage", var.osdu_chart_version)
-  enable                      = local.deploy_storage
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "storage"
+  image_repository = local.osdu_images["storage"].repository
+  image_tag        = local.osdu_images["storage"].tag
+  enable           = local.deploy_storage
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
+  istio_proxy_pin  = true
 
-  extra_set = [
-    {
-      name  = "data.servicebusTopic"
-      value = "recordstopic"
-    },
-    {
-      name  = "data.redisDatabase"
-      value = "4"
-    },
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "storage" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/storage/v2/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "COSMOSDB_DATABASE", value = "osdu-db" },
+    { name = "AZURE_SERVICEBUS_ENABLED", value = "true" },
+    { name = "AZURE_EVENTGRID_ENABLED", value = "false" },
+    { name = "SERVICEBUS_TOPIC_NAME", value = "recordstopic" },
+    { name = "SERVICEBUS_V2_TOPIC_NAME", value = "recordstopic-v2" },
+    { name = "REDIS_DATABASE", value = "4" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+    { name = "ENTITLEMENTS_SERVICE_ENDPOINT", value = "http://entitlements/api/entitlements/v2" },
+    { name = "ENTITLEMENTS_SERVICE_API_KEY", value = "OBSOLETE" },
+    { name = "LEGAL_SERVICE_ENDPOINT", value = "http://legal/api/legal/v1" },
+    { name = "LEGAL_SERVICE_REGION", value = "southcentralus" },
+    { name = "LEGAL_SERVICEBUS_TOPIC_NAME", value = "legaltagschangedtopiceg" },
+    { name = "LEGAL_SERVICEBUS_TOPIC_SUBSCRIPTION", value = "eg_sb_legaltagchangedsubscription" },
+    { name = "CRS_CONVERSION_SERVICE_ENDPOINT", value = "http://crs-conversion/api/crs/converter/v2" },
+    { name = "POLICY_SERVICE_ENDPOINT", value = "http://policy/api/policy/v1" },
+    { name = "OPA_ENABLED", value = "false" },
   ]
 
   preconditions = [
@@ -161,26 +207,33 @@ module "storage" {
 }
 
 module "search" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "search"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/system/search-service/cimpl-helm"
-  chart                       = "core-plus-search-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "search", var.osdu_chart_version)
-  enable                      = local.deploy_search
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "search"
+  image_repository = local.osdu_images["search"].repository
+  image_tag        = local.osdu_images["search"].tag
+  enable           = local.deploy_search
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
+  elastic_tls      = true
 
-  extra_set = [
-    {
-      name  = "data.redisDatabase"
-      value = "5"
-    },
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "search" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/search/v2/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "COSMOSDB_DATABASE", value = "osdu-db" },
+    { name = "REDIS_DATABASE", value = "5" },
+    { name = "ENVIRONMENT", value = "evt" },
+    { name = "ELASTIC_CACHE_EXPIRATION", value = "1" },
+    { name = "MAX_CACHE_VALUE_SIZE", value = "60" },
+    { name = "POLICY_SERVICE_ENABLED", value = "false" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+    { name = "ENTITLEMENTS_SERVICE_ENDPOINT", value = "http://entitlements/api/entitlements/v2" },
+    { name = "ENTITLEMENTS_SERVICE_API_KEY", value = "OBSOLETE" },
+    { name = "POLICY_SERVICE_ENDPOINT", value = "http://policy/api/policy/v1" },
   ]
 
   preconditions = [
@@ -194,30 +247,39 @@ module "search" {
 }
 
 module "indexer" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "indexer"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/system/indexer-service/cimpl-helm"
-  chart                       = "core-plus-indexer-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "indexer", var.osdu_chart_version)
-  enable                      = local.deploy_indexer
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "indexer"
+  image_repository = local.osdu_images["indexer"].repository
+  image_tag        = local.osdu_images["indexer"].tag
+  enable           = local.deploy_indexer
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
+  elastic_tls      = true
+  istio_proxy_pin  = true
 
-  extra_set = [
-    {
-      name  = "data.servicebusTopic"
-      value = "indexing-progress"
-    },
-    {
-      name  = "data.redisDatabase"
-      value = "4"
-    },
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "indexer" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/indexer/v2/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "SECURITY_HTTPS_CERTIFICATE_TRUST", value = "true" },
+    { name = "COSMOSDB_DATABASE", value = "osdu-db" },
+    { name = "SERVICEBUS_TOPIC_NAME", value = "indexing-progress" },
+    { name = "REINDEX_TOPIC_NAME", value = "recordstopic" },
+    { name = "REDIS_DATABASE", value = "4" },
+    { name = "REDIS_TTL_SECONDS", value = "3600" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+    { name = "ENTITLEMENTS_SERVICE_ENDPOINT", value = "http://entitlements/api/entitlements/v2" },
+    { name = "ENTITLEMENTS_SERVICE_API_KEY", value = "OBSOLETE" },
+    { name = "SCHEMA_SERVICE_URL", value = "http://schema/api/schema-service/v1" },
+    { name = "STORAGE_SERVICE_URL", value = "http://storage/api/storage/v2" },
+    { name = "STORAGE_SCHEMA_HOST", value = "http://storage/api/storage/v2/schemas" },
+    { name = "STORAGE_QUERY_RECORD_FOR_CONVERSION_HOST", value = "http://storage/api/storage/v2/query/records:batch" },
+    { name = "STORAGE_QUERY_RECORD_HOST", value = "http://storage/api/storage/v2/query/records" },
+    { name = "SEARCH_SERVICE_URL", value = "http://search/api/search/v2" },
   ]
 
   preconditions = [
@@ -231,26 +293,33 @@ module "indexer" {
 }
 
 module "indexer_queue" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "indexer-queue"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/system/indexer-queue/cimpl-helm"
-  chart                       = "core-plus-indexer-queue-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "indexer_queue", var.osdu_chart_version)
-  enable                      = local.deploy_indexer_queue
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "indexer-queue"
+  image_repository = local.osdu_images["indexer_queue"].repository
+  image_tag        = local.osdu_images["indexer_queue"].tag
+  enable           = local.deploy_indexer_queue
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
 
-  extra_set = [
-    {
-      name  = "data.servicebusTopic"
-      value = "recordstopicdownstream"
-    },
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "indexer-queue" },
+
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "AZURE_SERVICEBUS_TOPIC_NAME", value = "recordstopic" },
+    { name = "AZURE_REINDEX_TOPIC_NAME", value = "reindextopic" },
+    { name = "AZURE_SERVICEBUS_TOPIC_SUBSCRIPTION", value = "recordstopicsubscription" },
+    { name = "AZURE_REINDEX_TOPIC_SUBSCRIPTION", value = "reindextopicsubscription" },
+    { name = "AZURE_SCHEMACHANGED_TOPIC_NAME", value = "schemachangedtopic" },
+    { name = "AZURE_SCHEMACHANGED_TOPIC_SUBSCRIPTION", value = "schemachangedtopiceg" },
+    { name = "MAX_CONCURRENT_CALLS", value = "32" },
+    { name = "MAX_DELIVERY_COUNT", value = "5" },
+    { name = "EXECUTOR_N_THREADS", value = "32" },
+    { name = "MAX_LOCK_RENEW_DURATION_SECONDS", value = "600" },
+    { name = "PARTITION_API", value = "http://partition/api/partition/v1" },
+    { name = "INDEXER_WORKER_URL", value = "http://indexer/api/indexer/v2/_dps/task-handlers/index-worker" },
+    { name = "schema_worker_url", value = "http://indexer/api/indexer/v2/_dps/task-handlers/schema-worker" },
   ]
 
   preconditions = [
@@ -262,20 +331,37 @@ module "indexer_queue" {
 }
 
 module "file" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "file"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/system/file/cimpl-helm"
-  chart                       = "core-plus-file-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "file", var.osdu_chart_version)
-  enable                      = local.deploy_file
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "file"
+  image_repository = local.osdu_images["file"].repository
+  image_tag        = local.osdu_images["file"].tag
+  enable           = local.deploy_file
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
+  istio_proxy_pin  = true
+
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "file" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/file/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "SPRING_CONFIG_NAME", value = "common,application" },
+    { name = "COSMOSDB_DATABASE", value = "osdu-db" },
+    { name = "OSDU_ENTITLEMENTS_APP_KEY", value = "OBSOLETE" },
+    { name = "AZURE_PUBSUB_PUBLISH", value = "true" },
+    { name = "SERVICE_BUS_ENABLED_STATUS", value = "true" },
+    { name = "SERVICE_BUS_TOPIC_STATUS", value = "statuschangedtopic" },
+    { name = "BATCH_SIZE", value = "100" },
+    { name = "SEARCH_QUERY_LIMIT", value = "1000" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+    { name = "OSDU_ENTITLEMENTS_URL", value = "http://entitlements/api/entitlements/v2" },
+    { name = "authorizeAPI", value = "http://entitlements/api/entitlements/v2" },
+    { name = "OSDU_STORAGE_URL", value = "http://storage/api/storage/v2" },
+    { name = "SEARCH_HOST", value = "http://search/api/search/v2" },
+  ]
 
   preconditions = [
     { condition = !local.deploy_file || local.deploy_legal, error_message = "File requires Legal." },
@@ -287,26 +373,36 @@ module "file" {
 }
 
 module "workflow" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "workflow"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/data-flow/ingestion/ingestion-workflow/cimpl-helm"
-  chart                       = "core-plus-workflow-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "workflow", var.osdu_chart_version)
-  enable                      = local.deploy_workflow
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "workflow"
+  image_repository = local.osdu_images["workflow"].repository
+  image_tag        = local.osdu_images["workflow"].tag
+  enable           = local.deploy_workflow
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
 
-  extra_set = [
-    {
-      name  = "data.osduAirflowUrl"
-      value = "http://airflow-webserver.${local.platform_namespace}.svc.cluster.local:8080"
-    },
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "workflow" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/workflow/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "SPRING_CONFIG_NAME", value = "common,application" },
+    { name = "COSMOSDB_DATABASE", value = "osdu-db" },
+    { name = "COSMOSDB_SYSTEM_DATABASE", value = "osdu-system-db" },
+    { name = "AZURE_STORAGE_ENABLE_HTTPS", value = "true" },
+    { name = "AUTHORIZEAPI", value = "http://entitlements/api/entitlements/v2" },
+    { name = "AUTHORIZEAPIKEY", value = "OBSOLETE" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+    { name = "OSDU_ENTITLEMENTS_URL", value = "http://entitlements/api/entitlements/v2" },
+    { name = "OSDU_ENTITLEMENTS_APPKEY", value = "OBSOLETE" },
+    { name = "OSDU_AIRFLOW_URL", value = "http://airflow-web.${local.platform_namespace}.svc.cluster.local:8080/airflow" },
+    { name = "OSDU_AIRFLOW_VERSION2_ENABLED", value = "true" },
+    { name = "DP_AIRFLOW_FOR_SYSTEM_DAG", value = "false" },
+    { name = "IGNORE_DAGCONTENT", value = "true" },
+    { name = "IGNORE_CUSTOMOPERATORCONTENT", value = "true" },
   ]
 
   preconditions = [

--- a/software/stack/osdu-services-reference.tf
+++ b/software/stack/osdu-services-reference.tf
@@ -15,20 +15,28 @@
 # OSDU reference systems service deployments (Azure SPI variant)
 
 module "crs_conversion" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "crs-conversion"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/system/reference/crs-conversion-service/cimpl-helm"
-  chart                       = "core-plus-crs-conversion-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "crs_conversion", var.osdu_chart_version)
-  enable                      = local.deploy_crs_conversion
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "crs-conversion"
+  image_repository = local.osdu_images["crs_conversion"].repository
+  image_tag        = local.osdu_images["crs_conversion"].tag
+  enable           = local.deploy_crs_conversion
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
+
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "crs-conversion-service" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/crs/converter/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "SERVICE_DOMAIN_NAME", value = "dataservices.energy" },
+    { name = "SIS_DATA", value = "/apachesis_setup/SIS_DATA" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+    { name = "ENTITLEMENT_URL", value = "http://entitlements/api/entitlements/v2" },
+    { name = "STORAGE_URL", value = "http://storage/api/storage/v2" },
+  ]
 
   preconditions = [
     { condition = !local.deploy_crs_conversion || local.deploy_entitlements, error_message = "CRS Conversion requires Entitlements." },
@@ -39,20 +47,25 @@ module "crs_conversion" {
 }
 
 module "crs_catalog" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "crs-catalog"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/system/reference/crs-catalog-service/cimpl-helm"
-  chart                       = "core-plus-crs-catalog-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "crs_catalog", var.osdu_chart_version)
-  enable                      = local.deploy_crs_catalog
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "crs-catalog"
+  image_repository = local.osdu_images["crs_catalog"].repository
+  image_tag        = local.osdu_images["crs_catalog"].tag
+  enable           = local.deploy_crs_catalog
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
+
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "crs-catalog" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/crs/catalog/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+    { name = "ENTITLEMENT_URL", value = "http://entitlements/api/entitlements/v2" },
+  ]
 
   preconditions = [
     { condition = !local.deploy_crs_catalog || local.deploy_entitlements, error_message = "CRS Catalog requires Entitlements." },
@@ -63,20 +76,25 @@ module "crs_catalog" {
 }
 
 module "unit" {
-  source = "./modules/osdu-service"
+  source = "./modules/osdu-spi-service"
 
-  service_name                = "unit"
-  repository                  = "oci://community.opengroup.org:5555/osdu/platform/system/reference/unit-service/cimpl-helm"
-  chart                       = "core-plus-unit-deploy"
-  chart_version               = lookup(var.osdu_service_versions, "unit", var.osdu_chart_version)
-  enable                      = local.deploy_unit
-  enable_common               = local.deploy_common
-  namespace                   = local.osdu_namespace
-  osdu_domain                 = local.osdu_domain
-  data_partition              = var.data_partition
-  azure_tenant_id             = var.tenant_id
-  workload_identity_client_id = var.osdu_identity_client_id
-  kustomize_path              = path.module
+  service_name     = "unit"
+  image_repository = local.osdu_images["unit"].repository
+  image_tag        = local.osdu_images["unit"].tag
+  enable           = local.deploy_unit
+  enable_common    = local.deploy_common
+  namespace        = local.osdu_namespace
+
+  env = [
+    { name = "SPRING_APPLICATION_NAME", value = "unit" },
+    { name = "SERVER_SERVLET_CONTEXTPATH", value = "/api/unit/" },
+
+    { name = "ACCEPT_HTTP", value = "true" },
+    { name = "AZURE_ISTIOAUTH_ENABLED", value = "true" },
+    { name = "AZURE_PAAS_WORKLOADIDENTITY_ISENABLED", value = "true" },
+    { name = "PARTITION_SERVICE_ENDPOINT", value = "http://partition/api/partition/v1" },
+    { name = "ENTITLEMENT_URL", value = "http://entitlements/api/entitlements/v2" },
+  ]
 
   preconditions = [
     { condition = !local.deploy_unit || local.deploy_entitlements, error_message = "Unit requires Entitlements." },

--- a/software/stack/variables-osdu.tf
+++ b/software/stack/variables-osdu.tf
@@ -14,17 +14,19 @@
 
 # OSDU configuration variables (Azure SPI variant)
 
-# OSDU version management
-variable "osdu_chart_version" {
-  description = "Default OSDU Helm chart version for all services"
+variable "osdu_image_branch" {
+  description = "Branch suffix appended to OSDU image repository names (e.g. 'master', 'release-0-27')"
   type        = string
-  default     = "0.0.7-latest"
+  default     = "master"
 }
 
-variable "osdu_service_versions" {
-  description = "Per-service version overrides (service_name -> chart_version)"
-  type        = map(string)
-  default     = {}
+variable "osdu_image_overrides" {
+  description = "Per-service image overrides (service key -> {repository, tag})"
+  type = map(object({
+    repository = string
+    tag        = string
+  }))
+  default = {}
 }
 
 variable "osdu_airflow_version" {


### PR DESCRIPTION
## Summary
- New `osdu-spi-service` Helm chart with AKS Automatic compliance baked in (seccomp, runAsNonRoot, topology spread)
- New `osdu-spi-service` Terraform module replacing CIMPL OCI chart + kustomize postrender approach
- Azure SPI images from OSDU community registry with full 40-char SHA tags
- All 10 core + 3 reference service configs with env vars aligned to osdu-developer
- ConfigMap keys uppercased to match Java service expectations (KEYVAULT_URI, AAD_CLIENT_ID, etc.)
- Elasticsearch upgraded to 8.18.2

## Deployment Status (spi environment)
- **Healthy**: partition, entitlements, legal, storage (4/10 core)
- **Pending fixes**: schema (EVENT_GRID_TOPIC), file (SERVER_PORT), indexer/workflow (Redis SSL), indexer-queue (not deployed yet)
- **Disabled**: reference services (need PVC infrastructure for catalog data)

## Key Vault secrets needed
Services read bootstrap config from Key Vault. Required secrets: `tbl-storage-endpoint`, `app-dev-sp-password`, `app-dev-sp-username`, `app-dev-sp-tenant-id`, `redis-hostname`, `redis-password`, `redis-port`

## Test plan
- [x] Helm chart validates (`helm template`)
- [x] Partition starts and passes health probes
- [x] Entitlements starts and passes health probes
- [x] Legal starts and passes health probes
- [x] Storage starts and passes health probes
- [ ] Schema needs EVENT_GRID_TOPIC env var
- [ ] File/indexer/workflow need SERVER_PORT and Redis SSL config
- [ ] End-to-end API test