### PR TITLE
fix: migrate kubectl provider and fix Keycloak issuer mismatch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,7 +64,7 @@ updates:
         patterns:
           - "hashicorp/helm"
           - "hashicorp/kubernetes"
-          - "gavinbunney/kubectl"
+          - "alekc/kubectl"
 
   - package-ecosystem: "terraform"
     directory: "/software/spi-stack"
@@ -84,7 +84,7 @@ updates:
         patterns:
           - "hashicorp/helm"
           - "hashicorp/kubernetes"
-          - "gavinbunney/kubectl"
+          - "alekc/kubectl"
       hashicorp-utilities:
         patterns:
           - "hashicorp/null"

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -15,9 +15,9 @@
 # Derived names and partition processing for the infrastructure layer.
 
 locals {
-  # Resource naming: spi-<env_name> allows multiple deployments
-  resource_group_name = "rg-spi-${var.environment_name}"
-  cluster_name        = "spi-${var.environment_name}"
+  # Resource naming: osdu-<env_name> allows multiple deployments
+  resource_group_name = "osdu-${var.environment_name}"
+  cluster_name        = "osdu-${var.environment_name}"
 
   # Azure Managed Grafana names are limited to 23 characters.
   grafana_name = trimsuffix(substr("${local.cluster_name}-grafana", 0, 23), "-")
@@ -25,7 +25,7 @@ locals {
   # Standard tags applied to all Azure resources.
   common_tags = merge(var.tags, {
     "azd-env-name" = var.environment_name
-    "project"      = "osdu-spi"
+    "project"      = "osdu"
     "Contact"      = var.contact_email
   })
 

--- a/software/cimpl-stack/.terraform.lock.hcl
+++ b/software/cimpl-stack/.terraform.lock.hcl
@@ -1,26 +1,24 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/gavinbunney/kubectl" {
-  version     = "1.19.0"
-  constraints = "~> 1.19.0"
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.2.0"
+  constraints = "~> 2.1"
   hashes = [
-    "h1:quymfa/OKEfWI5JXFEwGbUY2aAy0vet3rA9JWJam+3k=",
-    "zh:1dec8766336ac5b00b3d8f62e3fff6390f5f60699c9299920fc9861a76f00c71",
-    "zh:43f101b56b58d7fead6a511728b4e09f7c41dc2e3963f59cf1c146c4767c6cb7",
-    "zh:4c4fbaa44f60e722f25cc05ee11dfaec282893c5c0ffa27bc88c382dbfbaa35c",
-    "zh:51dd23238b7b677b8a1abbfcc7deec53ffa5ec79e58e3b54d6be334d3d01bc0e",
-    "zh:5afc2ebc75b9d708730dbabdc8f94dd559d7f2fc5a31c5101358bd8d016916ba",
-    "zh:6be6e72d4663776390a82a37e34f7359f726d0120df622f4a2b46619338a168e",
-    "zh:72642d5fcf1e3febb6e5d4ae7b592bb9ff3cb220af041dbda893588e4bf30c0c",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a1da03e3239867b35812ee031a1060fed6e8d8e458e2eaca48b5dd51b35f56f7",
-    "zh:b98b6a6728fe277fcd133bdfa7237bd733eae233f09653523f14460f608f8ba2",
-    "zh:bb8b071d0437f4767695c6158a3cb70df9f52e377c67019971d888b99147511f",
-    "zh:dc89ce4b63bfef708ec29c17e85ad0232a1794336dc54dd88c3ba0b77e764f71",
-    "zh:dd7dd18f1f8218c6cd19592288fde32dccc743cde05b9feeb2883f37c2ff4b4e",
-    "zh:ec4bd5ab3872dedb39fe528319b4bba609306e12ee90971495f109e142d66310",
-    "zh:f610ead42f724c82f5463e0e71fa735a11ffb6101880665d93f48b4a67b9ad82",
+    "h1:UMcNNSk7bFSs3gzn/+8d6j2/lK+PEUKV4CSrjP6N6nA=",
+    "zh:0187d07fbfc6960c8f1e5a0a10f686ff989af070dad3c703825e7b36d9f4752b",
+    "zh:0d010cb68aea779e8468b267a066f55a27556ef32f864faee8252b777ef1bd26",
+    "zh:15527360858690bc2b522a0c9d90b3a650a798852d80b9311daa7e9f7def658d",
+    "zh:3f3fa891c3d254cd98b3bca8f7043bf05073c8efa71eedc98dfc8e8baa8a7176",
+    "zh:6336b4d3d609e650262e7ab2ef0da4c64ae74e9bda1669b995667221c527ba63",
+    "zh:81b7f6fae7068d0d1acb271112d562b797a74a67befa9a2f67549d420e27ecff",
+    "zh:8806ac0c4c3d4375bdd9845168efab7c30bfe74ce11fb261de5b7734196bcdba",
+    "zh:97e8bb627306a7713f9e3907efdcefbe9c8106b22f24dc72b81bbdd07e1e92dd",
+    "zh:97fa713ced8a9e2021b6fa0cae1d094ab3b7cb81c546364c2599025f7bcc446a",
+    "zh:9cd9bb21b584f6f5c09a27345fbe768f1af46f5b81a8ac42cace8a339cd16c00",
+    "zh:b8bb1fba5589d5f3ebd7aadd146e112bcf442b7824cfaeba27a13a6855c52c20",
+    "zh:cef8aec0abbfb4a51e8e4e5f1172ae45eff8fe4ad2115c8ab68f7b8f0599ff8d",
+    "zh:fdc80bb8d96b273c46cce3a21c313504993f0f6d5e855c7eff40b2f056193a52",
   ]
 }
 

--- a/software/cimpl-stack/kustomize/postrender.ps1
+++ b/software/cimpl-stack/kustomize/postrender.ps1
@@ -81,7 +81,7 @@ try {
     # 2. Add internal Keycloak issuer to RequestAuthentication jwtRules
     #    so tokens issued via internal FQDN are accepted by Istio
     if ($PlatformNamespace -and $ReleaseNamespace) {
-        $internalKeycloak = "keycloak.$PlatformNamespace.svc.cluster.local:8080"
+        $internalKeycloak = "keycloak.$PlatformNamespace.svc.cluster.local"
         $kustomizeOutput = $kustomizeOutput -replace "keycloak\.$([regex]::Escape($ReleaseNamespace))\.svc\.cluster\.local(?!:\d)", $internalKeycloak
 
         # Add internal issuer to RequestAuthentication: inject an additional

--- a/software/cimpl-stack/modules/airflow/main.tf
+++ b/software/cimpl-stack/modules/airflow/main.tf
@@ -161,7 +161,7 @@ resource "helm_release" "airflow" {
       - name: CLOUD_PROVIDER
         value: "baremetal"
       - name: KEYCLOAK_AUTH_URL
-        value: "http://${var.keycloak_host}:8080/realms/osdu/protocol/openid-connect/token"
+        value: "http://${var.keycloak_host}/realms/osdu/protocol/openid-connect/token"
       - name: KEYCLOAK_CLIENT_ID
         value: "datafier"
       - name: KEYCLOAK_CLIENT_SECRET

--- a/software/cimpl-stack/modules/elastic/versions.tf
+++ b/software/cimpl-stack/modules/elastic/versions.tf
@@ -18,7 +18,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
     helm = {
       source = "hashicorp/helm"

--- a/software/cimpl-stack/modules/gateway/versions.tf
+++ b/software/cimpl-stack/modules/gateway/versions.tf
@@ -15,7 +15,7 @@
 terraform {
   required_providers {
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
   }
 }

--- a/software/cimpl-stack/modules/keycloak/keycloak-jwks-wait.ps1
+++ b/software/cimpl-stack/modules/keycloak/keycloak-jwks-wait.ps1
@@ -61,7 +61,7 @@ $portForwardProc = $null
 try {
     # Start kubectl port-forward as a background process
     $portForwardProc = Start-Process kubectl `
-        -ArgumentList "port-forward", "svc/keycloak", "-n", $Namespace, "28080:8080" `
+        -ArgumentList "port-forward", "svc/keycloak", "-n", $Namespace, "28080:80" `
         -NoNewWindow -PassThru
 
     # Give the port-forward a moment to establish

--- a/software/cimpl-stack/modules/keycloak/main.tf
+++ b/software/cimpl-stack/modules/keycloak/main.tf
@@ -118,7 +118,7 @@ resource "kubectl_manifest" "keycloak_headless_service" {
       publishNotReadyAddresses: true
       ports:
         - name: http
-          port: 8080
+          port: 80
           targetPort: http
           protocol: TCP
       selector:
@@ -142,7 +142,7 @@ resource "kubectl_manifest" "keycloak_service" {
       sessionAffinity: None
       ports:
         - name: http
-          port: 8080
+          port: 80
           targetPort: http
           protocol: TCP
       selector:

--- a/software/cimpl-stack/modules/keycloak/versions.tf
+++ b/software/cimpl-stack/modules/keycloak/versions.tf
@@ -18,7 +18,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
     random = {
       source = "hashicorp/random"

--- a/software/cimpl-stack/modules/osdu-common/secrets-identity.tf
+++ b/software/cimpl-stack/modules/osdu-common/secrets-identity.tf
@@ -25,7 +25,7 @@ resource "kubernetes_secret_v1" "datafier" {
   data = {
     OPENID_PROVIDER_CLIENT_ID     = "datafier"
     OPENID_PROVIDER_CLIENT_SECRET = var.datafier_client_secret
-    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}:8080/realms/osdu"
+    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}/realms/osdu"
   }
 
   depends_on = [kubernetes_namespace_v1.osdu]
@@ -42,7 +42,7 @@ resource "kubernetes_secret_v1" "storage_keycloak" {
   data = {
     OPENID_PROVIDER_CLIENT_ID     = "datafier"
     OPENID_PROVIDER_CLIENT_SECRET = var.datafier_client_secret
-    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}:8080/realms/osdu"
+    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}/realms/osdu"
   }
 
   depends_on = [kubernetes_namespace_v1.osdu]
@@ -59,7 +59,7 @@ resource "kubernetes_secret_v1" "file_keycloak" {
   data = {
     OPENID_PROVIDER_CLIENT_ID     = "datafier"
     OPENID_PROVIDER_CLIENT_SECRET = var.datafier_client_secret
-    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}:8080/realms/osdu"
+    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}/realms/osdu"
   }
 
   depends_on = [kubernetes_namespace_v1.osdu]
@@ -76,7 +76,7 @@ resource "kubernetes_secret_v1" "notification_keycloak" {
   data = {
     OPENID_PROVIDER_CLIENT_ID     = "datafier"
     OPENID_PROVIDER_CLIENT_SECRET = var.datafier_client_secret
-    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}:8080/realms/osdu"
+    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}/realms/osdu"
   }
 
   depends_on = [kubernetes_namespace_v1.osdu]
@@ -93,7 +93,7 @@ resource "kubernetes_secret_v1" "register_keycloak" {
   data = {
     OPENID_PROVIDER_CLIENT_ID     = "datafier"
     OPENID_PROVIDER_CLIENT_SECRET = var.datafier_client_secret
-    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}:8080/realms/osdu"
+    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}/realms/osdu"
   }
 
   depends_on = [kubernetes_namespace_v1.osdu]
@@ -125,7 +125,7 @@ resource "kubernetes_secret_v1" "workflow_keycloak" {
   data = {
     OPENID_PROVIDER_CLIENT_ID     = "datafier"
     OPENID_PROVIDER_CLIENT_SECRET = var.datafier_client_secret
-    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}:8080/realms/osdu"
+    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}/realms/osdu"
   }
 
   depends_on = [kubernetes_namespace_v1.osdu]
@@ -142,7 +142,7 @@ resource "kubernetes_secret_v1" "indexer_keycloak" {
   data = {
     OPENID_PROVIDER_CLIENT_ID     = "datafier"
     OPENID_PROVIDER_CLIENT_SECRET = var.datafier_client_secret
-    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}:8080/realms/osdu"
+    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}/realms/osdu"
   }
 
   depends_on = [kubernetes_namespace_v1.osdu]
@@ -159,7 +159,7 @@ resource "kubernetes_secret_v1" "wellbore_keycloak" {
   data = {
     OPENID_PROVIDER_CLIENT_ID     = "datafier"
     OPENID_PROVIDER_CLIENT_SECRET = var.datafier_client_secret
-    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}:8080/realms/osdu"
+    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}/realms/osdu"
   }
 
   depends_on = [kubernetes_namespace_v1.osdu]
@@ -176,7 +176,7 @@ resource "kubernetes_secret_v1" "eds_keycloak" {
   data = {
     OPENID_PROVIDER_CLIENT_ID     = "datafier"
     OPENID_PROVIDER_CLIENT_SECRET = var.datafier_client_secret
-    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}:8080/realms/osdu"
+    OPENID_PROVIDER_URL           = "http://${var.keycloak_host}/realms/osdu"
   }
 
   depends_on = [kubernetes_namespace_v1.osdu]
@@ -193,7 +193,7 @@ resource "kubernetes_secret_v1" "oetp_server_secret" {
   data = {
     CIMPL_CLIENT_ID                 = "datafier"
     CIMPL_CLIENT_SECRET             = var.datafier_client_secret
-    CIMPL_TOKEN_URI                 = "http://${var.keycloak_host}:8080/realms/osdu/protocol/openid-connect/token"
+    CIMPL_TOKEN_URI                 = "http://${var.keycloak_host}/realms/osdu/protocol/openid-connect/token"
     CIMPL_SUBSCRIBER_PRIVATE_KEY_ID = var.cimpl_subscriber_private_key_id
   }
 

--- a/software/cimpl-stack/modules/osdu-common/versions.tf
+++ b/software/cimpl-stack/modules/osdu-common/versions.tf
@@ -18,7 +18,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
   }
 }

--- a/software/cimpl-stack/modules/postgresql/versions.tf
+++ b/software/cimpl-stack/modules/postgresql/versions.tf
@@ -18,7 +18,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
   }
 }

--- a/software/cimpl-stack/modules/rabbitmq/versions.tf
+++ b/software/cimpl-stack/modules/rabbitmq/versions.tf
@@ -18,7 +18,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
   }
 }

--- a/software/cimpl-stack/scripts/bootstrap-data-seed-job.py
+++ b/software/cimpl-stack/scripts/bootstrap-data-seed-job.py
@@ -20,7 +20,7 @@ Creates a default legal tag and loads OSDU reference data via the Storage API.
 All service calls use in-cluster FQDNs (no kubectl port-forward).
 
 Environment variables:
-  KEYCLOAK_URL              Keycloak base URL (e.g. http://keycloak.platform:8080)
+  KEYCLOAK_URL              Keycloak base URL (e.g. http://keycloak.platform)
   LEGAL_URL                 Legal service base URL (e.g. http://legal.osdu)
   STORAGE_URL               Storage service base URL (e.g. http://storage.osdu)
   DATA_PARTITION            Data partition ID (e.g. "osdu")

--- a/software/cimpl-stack/scripts/bootstrap-data-seed.ps1
+++ b/software/cimpl-stack/scripts/bootstrap-data-seed.ps1
@@ -124,7 +124,7 @@ spec:
             - name: PYTHONUNBUFFERED
               value: "1"
             - name: KEYCLOAK_URL
-              value: "http://keycloak.${PlatformNamespace}.svc.cluster.local:8080"
+              value: "http://keycloak.${PlatformNamespace}.svc.cluster.local"
             - name: LEGAL_URL
               value: "http://legal.${OsduNamespace}.svc.cluster.local"
             - name: STORAGE_URL

--- a/software/cimpl-stack/versions.tf
+++ b/software/cimpl-stack/versions.tf
@@ -29,8 +29,8 @@ terraform {
       version = "~> 3.1"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "~> 1.19.0"
+      source  = "alekc/kubectl"
+      version = "~> 2.1"
     }
     null = {
       source  = "hashicorp/null"

--- a/software/foundation/.terraform.lock.hcl
+++ b/software/foundation/.terraform.lock.hcl
@@ -1,26 +1,24 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/gavinbunney/kubectl" {
-  version     = "1.19.0"
-  constraints = "~> 1.19.0"
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.2.0"
+  constraints = "~> 2.1"
   hashes = [
-    "h1:quymfa/OKEfWI5JXFEwGbUY2aAy0vet3rA9JWJam+3k=",
-    "zh:1dec8766336ac5b00b3d8f62e3fff6390f5f60699c9299920fc9861a76f00c71",
-    "zh:43f101b56b58d7fead6a511728b4e09f7c41dc2e3963f59cf1c146c4767c6cb7",
-    "zh:4c4fbaa44f60e722f25cc05ee11dfaec282893c5c0ffa27bc88c382dbfbaa35c",
-    "zh:51dd23238b7b677b8a1abbfcc7deec53ffa5ec79e58e3b54d6be334d3d01bc0e",
-    "zh:5afc2ebc75b9d708730dbabdc8f94dd559d7f2fc5a31c5101358bd8d016916ba",
-    "zh:6be6e72d4663776390a82a37e34f7359f726d0120df622f4a2b46619338a168e",
-    "zh:72642d5fcf1e3febb6e5d4ae7b592bb9ff3cb220af041dbda893588e4bf30c0c",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a1da03e3239867b35812ee031a1060fed6e8d8e458e2eaca48b5dd51b35f56f7",
-    "zh:b98b6a6728fe277fcd133bdfa7237bd733eae233f09653523f14460f608f8ba2",
-    "zh:bb8b071d0437f4767695c6158a3cb70df9f52e377c67019971d888b99147511f",
-    "zh:dc89ce4b63bfef708ec29c17e85ad0232a1794336dc54dd88c3ba0b77e764f71",
-    "zh:dd7dd18f1f8218c6cd19592288fde32dccc743cde05b9feeb2883f37c2ff4b4e",
-    "zh:ec4bd5ab3872dedb39fe528319b4bba609306e12ee90971495f109e142d66310",
-    "zh:f610ead42f724c82f5463e0e71fa735a11ffb6101880665d93f48b4a67b9ad82",
+    "h1:UMcNNSk7bFSs3gzn/+8d6j2/lK+PEUKV4CSrjP6N6nA=",
+    "zh:0187d07fbfc6960c8f1e5a0a10f686ff989af070dad3c703825e7b36d9f4752b",
+    "zh:0d010cb68aea779e8468b267a066f55a27556ef32f864faee8252b777ef1bd26",
+    "zh:15527360858690bc2b522a0c9d90b3a650a798852d80b9311daa7e9f7def658d",
+    "zh:3f3fa891c3d254cd98b3bca8f7043bf05073c8efa71eedc98dfc8e8baa8a7176",
+    "zh:6336b4d3d609e650262e7ab2ef0da4c64ae74e9bda1669b995667221c527ba63",
+    "zh:81b7f6fae7068d0d1acb271112d562b797a74a67befa9a2f67549d420e27ecff",
+    "zh:8806ac0c4c3d4375bdd9845168efab7c30bfe74ce11fb261de5b7734196bcdba",
+    "zh:97e8bb627306a7713f9e3907efdcefbe9c8106b22f24dc72b81bbdd07e1e92dd",
+    "zh:97fa713ced8a9e2021b6fa0cae1d094ab3b7cb81c546364c2599025f7bcc446a",
+    "zh:9cd9bb21b584f6f5c09a27345fbe768f1af46f5b81a8ac42cace8a339cd16c00",
+    "zh:b8bb1fba5589d5f3ebd7aadd146e112bcf442b7824cfaeba27a13a6855c52c20",
+    "zh:cef8aec0abbfb4a51e8e4e5f1172ae45eff8fe4ad2115c8ab68f7b8f0599ff8d",
+    "zh:fdc80bb8d96b273c46cce3a21c313504993f0f6d5e855c7eff40b2f056193a52",
   ]
 }
 

--- a/software/foundation/charts/cert-manager/versions.tf
+++ b/software/foundation/charts/cert-manager/versions.tf
@@ -18,7 +18,7 @@ terraform {
       source = "hashicorp/helm"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
   }
 }

--- a/software/foundation/versions.tf
+++ b/software/foundation/versions.tf
@@ -25,8 +25,8 @@ terraform {
       version = "~> 3.1"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "~> 1.19.0"
+      source  = "alekc/kubectl"
+      version = "~> 2.1"
     }
   }
 }

--- a/software/spi-stack/.terraform.lock.hcl
+++ b/software/spi-stack/.terraform.lock.hcl
@@ -1,26 +1,24 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/gavinbunney/kubectl" {
-  version     = "1.19.0"
-  constraints = "~> 1.19.0"
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.2.0"
+  constraints = "~> 2.1"
   hashes = [
-    "h1:quymfa/OKEfWI5JXFEwGbUY2aAy0vet3rA9JWJam+3k=",
-    "zh:1dec8766336ac5b00b3d8f62e3fff6390f5f60699c9299920fc9861a76f00c71",
-    "zh:43f101b56b58d7fead6a511728b4e09f7c41dc2e3963f59cf1c146c4767c6cb7",
-    "zh:4c4fbaa44f60e722f25cc05ee11dfaec282893c5c0ffa27bc88c382dbfbaa35c",
-    "zh:51dd23238b7b677b8a1abbfcc7deec53ffa5ec79e58e3b54d6be334d3d01bc0e",
-    "zh:5afc2ebc75b9d708730dbabdc8f94dd559d7f2fc5a31c5101358bd8d016916ba",
-    "zh:6be6e72d4663776390a82a37e34f7359f726d0120df622f4a2b46619338a168e",
-    "zh:72642d5fcf1e3febb6e5d4ae7b592bb9ff3cb220af041dbda893588e4bf30c0c",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a1da03e3239867b35812ee031a1060fed6e8d8e458e2eaca48b5dd51b35f56f7",
-    "zh:b98b6a6728fe277fcd133bdfa7237bd733eae233f09653523f14460f608f8ba2",
-    "zh:bb8b071d0437f4767695c6158a3cb70df9f52e377c67019971d888b99147511f",
-    "zh:dc89ce4b63bfef708ec29c17e85ad0232a1794336dc54dd88c3ba0b77e764f71",
-    "zh:dd7dd18f1f8218c6cd19592288fde32dccc743cde05b9feeb2883f37c2ff4b4e",
-    "zh:ec4bd5ab3872dedb39fe528319b4bba609306e12ee90971495f109e142d66310",
-    "zh:f610ead42f724c82f5463e0e71fa735a11ffb6101880665d93f48b4a67b9ad82",
+    "h1:UMcNNSk7bFSs3gzn/+8d6j2/lK+PEUKV4CSrjP6N6nA=",
+    "zh:0187d07fbfc6960c8f1e5a0a10f686ff989af070dad3c703825e7b36d9f4752b",
+    "zh:0d010cb68aea779e8468b267a066f55a27556ef32f864faee8252b777ef1bd26",
+    "zh:15527360858690bc2b522a0c9d90b3a650a798852d80b9311daa7e9f7def658d",
+    "zh:3f3fa891c3d254cd98b3bca8f7043bf05073c8efa71eedc98dfc8e8baa8a7176",
+    "zh:6336b4d3d609e650262e7ab2ef0da4c64ae74e9bda1669b995667221c527ba63",
+    "zh:81b7f6fae7068d0d1acb271112d562b797a74a67befa9a2f67549d420e27ecff",
+    "zh:8806ac0c4c3d4375bdd9845168efab7c30bfe74ce11fb261de5b7734196bcdba",
+    "zh:97e8bb627306a7713f9e3907efdcefbe9c8106b22f24dc72b81bbdd07e1e92dd",
+    "zh:97fa713ced8a9e2021b6fa0cae1d094ab3b7cb81c546364c2599025f7bcc446a",
+    "zh:9cd9bb21b584f6f5c09a27345fbe768f1af46f5b81a8ac42cace8a339cd16c00",
+    "zh:b8bb1fba5589d5f3ebd7aadd146e112bcf442b7824cfaeba27a13a6855c52c20",
+    "zh:cef8aec0abbfb4a51e8e4e5f1172ae45eff8fe4ad2115c8ab68f7b8f0599ff8d",
+    "zh:fdc80bb8d96b273c46cce3a21c313504993f0f6d5e855c7eff40b2f056193a52",
   ]
 }
 

--- a/software/spi-stack/modules/elastic/versions.tf
+++ b/software/spi-stack/modules/elastic/versions.tf
@@ -18,7 +18,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
     helm = {
       source = "hashicorp/helm"

--- a/software/spi-stack/modules/gateway/versions.tf
+++ b/software/spi-stack/modules/gateway/versions.tf
@@ -15,7 +15,7 @@
 terraform {
   required_providers {
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
   }
 }

--- a/software/spi-stack/modules/osdu-common/versions.tf
+++ b/software/spi-stack/modules/osdu-common/versions.tf
@@ -18,7 +18,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
   }
 }

--- a/software/spi-stack/modules/postgresql/versions.tf
+++ b/software/spi-stack/modules/postgresql/versions.tf
@@ -18,7 +18,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
   }
 }

--- a/software/spi-stack/modules/redis/versions.tf
+++ b/software/spi-stack/modules/redis/versions.tf
@@ -21,7 +21,7 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source = "alekc/kubectl"
     }
   }
 }

--- a/software/spi-stack/versions.tf
+++ b/software/spi-stack/versions.tf
@@ -29,8 +29,8 @@ terraform {
       version = "~> 3.1"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "~> 1.19.0"
+      source  = "alekc/kubectl"
+      version = "~> 2.1"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## Summary

This merge request updates the Terraform kubectl provider from `gavinbunney/kubectl` to `alekc/kubectl`, standardizes Keycloak service port configuration, and refactors resource naming conventions from "spi" to "osdu".

## Key Modifications

### Provider Migration
- Migrated kubectl provider from `gavinbunney/kubectl` v1.19.0 to `alekc/kubectl` v2.1/v2.2.0 across all Terraform modules and lock files
- Updated Dependabot configuration to track the new provider source
- Modified 15+ `versions.tf` files across foundation, cimpl-stack, and spi-stack directories

### Keycloak Port Standardization
- Changed Keycloak service port from 8080 to 80 in Kubernetes service definitions (`keycloak/main.tf`)
- Updated all internal Keycloak URLs from `http://keycloak.*:8080` to `http://keycloak.*` across:
  - OSDU service secrets (datafier, storage, file, notification, register, workflow, indexer, wellbore, eds)
  - Airflow environment variables
  - OETP server configuration
  - Bootstrap data seed scripts and jobs
- Modified port-forward configuration in `keycloak-jwks-wait.ps1` from `28080:8080` to `28080:80`
- Updated Kustomize postrender script to use `keycloak.$PlatformNamespace.svc.cluster.local` without explicit port

### Resource Naming Refactoring
- Changed Azure resource naming prefix from "spi" to "osdu" in `infra/locals.tf`:
  - Resource group: `rg-spi-${var.environment_name}` → `osdu-${var.environment_name}`
  - Cluster name: `spi-${var.environment_name}` → `osdu-${var.environment_name}`
- Updated project tag from "osdu-spi" to "osdu"

### Documentation Updates
- Updated Python script docstring to reflect new Keycloak URL format without port specification