### PR TITLE
fix(istio): resolve CIMPL Keycloak auth for internal service tokens

### DIFF
--- a/software/cimpl-stack/kustomize/postrender.ps1
+++ b/software/cimpl-stack/kustomize/postrender.ps1
@@ -73,16 +73,19 @@ try {
     }
 
     # Run kustomize and filter out Namespace resources
-    $kustomizeOutput = kubectl kustomize $TempServiceDir
+    # Join into single string so cross-line regex replacements work correctly
+    $kustomizeOutput = (kubectl kustomize $TempServiceDir) -join "`n"
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     # Fix Keycloak cross-namespace references:
-    # 1. Rewrite jwksUri from osdu namespace to platform namespace
+    # 1. Rewrite FQDN references from osdu namespace to platform namespace
     # 2. Add internal Keycloak issuer to RequestAuthentication jwtRules
+    # 3. Add internal Keycloak issuer to AuthorizationPolicy iss claim checks
     #    so tokens issued via internal FQDN are accepted by Istio
     if ($PlatformNamespace -and $ReleaseNamespace) {
         $internalKeycloak = "keycloak.$PlatformNamespace.svc.cluster.local"
-        $kustomizeOutput = $kustomizeOutput -replace "keycloak\.$([regex]::Escape($ReleaseNamespace))\.svc\.cluster\.local(?!:\d)", $internalKeycloak
+        # Rewrite FQDN references (with or without port) to platform namespace without port
+        $kustomizeOutput = $kustomizeOutput -replace "keycloak\.$([regex]::Escape($ReleaseNamespace))\.svc\.cluster\.local(:\d+)?", $internalKeycloak
 
         # Add internal issuer to RequestAuthentication: inject an additional
         # jwtRule that accepts tokens with the internal Keycloak issuer URL
@@ -93,12 +96,15 @@ try {
     issuer: $internalIssuer
     jwksUri: $internalJwksUri
 "@
-        # Append after the last jwtRule in any RequestAuthentication
-        $kustomizeOutput = $kustomizeOutput -replace '(issuer: http://keycloak/realms/osdu\s+jwksUri: [^\n]+)', "`$1`n$internalRule"
+        # Append after the last jwtRule in any RequestAuthentication (with or without port)
+        $kustomizeOutput = $kustomizeOutput -replace '(issuer: http://keycloak(:\d+)?/realms/osdu\s+jwksUri: [^\n]+)', "`$1`n$internalRule"
+
+        # Add internal issuer to AuthorizationPolicy iss claim value lists
+        $kustomizeOutput = $kustomizeOutput -replace '(- http://keycloak(:\d+)?/realms/osdu)', "`$1`n      - $internalIssuer"
     }
 
     # Split on YAML document separators and filter out Namespace resources
-    $documents = ($kustomizeOutput -join "`n") -split '(?m)^---$'
+    $documents = $kustomizeOutput -split '(?m)^---$'
     foreach ($doc in $documents) {
         if ([string]::IsNullOrWhiteSpace($doc)) { continue }
         if ($doc -match '(?m)^kind:\s*Namespace\s*$') { continue }

--- a/software/cimpl-stack/modules/osdu-common/services.tf
+++ b/software/cimpl-stack/modules/osdu-common/services.tf
@@ -42,7 +42,7 @@ resource "kubectl_manifest" "osdu_peer_authentication" {
       namespace: ${var.namespace}
     spec:
       mtls:
-        mode: STRICT
+        mode: PERMISSIVE
   YAML
 
   depends_on = [kubernetes_namespace_v1.osdu]


### PR DESCRIPTION
## Summary
This change modifies Istio security configurations and Keycloak reference handling in the OSDU deployment, specifically adjusting mTLS requirements and improving cross-namespace service communication patterns.

## Key Modifications

### Keycloak Cross-Namespace Reference Handling (`postrender.ps1`)
- **Port-agnostic FQDN rewriting**: Updated regex pattern to handle Keycloak service references with or without port numbers (`keycloak.$namespace.svc.cluster.local:8080` → `keycloak.$platformNamespace.svc.cluster.local`)
- **RequestAuthentication enhancement**: Modified jwtRule injection to match issuer URLs regardless of port specification (`http://keycloak/realms/osdu` or `http://keycloak:8080/realms/osdu`)
- **AuthorizationPolicy issuer claims**: Added automatic injection of internal Keycloak issuer to `iss` claim value lists in AuthorizationPolicy resources, ensuring tokens issued via internal FQDN are validated correctly

### String Processing Optimization
- Changed kustomize output handling to join array into single string before regex operations, enabling cross-line pattern matching for multi-line YAML structures
- Removed redundant string join operation when splitting documents (now operates on already-joined string)

### mTLS Configuration Change (`services.tf`)
- **Relaxed peer authentication mode**: Changed OSDU namespace PeerAuthentication from `STRICT` to `PERMISSIVE` mTLS mode
- This allows the namespace to accept both mTLS and plaintext traffic, rather than requiring mutual TLS for all service-to-service communication

## Technical Details

The regex pattern `keycloak\.$([regex]::Escape($ReleaseNamespace))\.svc\.cluster\.local(:\d+)?` now captures optional port numbers using the `(:\d+)?` group, ensuring consistent rewriting regardless of how services reference Keycloak internally.

The AuthorizationPolicy modification uses backreference replacement to insert the internal issuer immediately after existing issuer entries: `- http://keycloak/realms/osdu` becomes a multi-line list including both external and internal issuer URLs